### PR TITLE
Add travis.yml file to connect with Travis-CI

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "3.6"
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+# command to run tests
+script:
+  - make test


### PR DESCRIPTION
This PR adds a `travis.yml` file to run tests with Travis-CI. Travis won't begin running tests until this file is added to the repository. This is an initial test that should run the `make test` script which for now just runs the python unit tests and linter. 

The next steps are to confirm that this script runs as part of a future PR build, and then improve the configuration to also run `mypy` type checks, as well as anything else that would be a good practice.