### PR TITLE
Set the elasticsearch base (endpoint) from env variable 

### DIFF
--- a/search_service/config.py
+++ b/search_service/config.py
@@ -1,3 +1,5 @@
+import os
+
 ELASTICSEARCH_ENDPOINT_KEY = 'ELASTICSEARCH_ENDPOINT'
 ELASTICSEARCH_INDEX_KEY = 'ELASTICSEARCH_INDEX'
 ELASTICSEARCH_AUTH_USER_KEY = 'ELASTICSEARCH_AUTH_USER'
@@ -19,7 +21,12 @@ class LocalConfig(Config):
     TESTING = False
     STATS = False
     LOCAL_HOST = '0.0.0.0'
-    ELASTICSEARCH_ENDPOINT = 'http://{LOCAL_HOST}:9200'.format(LOCAL_HOST=LOCAL_HOST)
+    ELASTICSEARCH_PORT = '9200'
+    ELASTICSEARCH_ENDPOINT = os.environ.get('ELASTICSEARCH_BASE',
+                                        'http://{LOCAL_HOST}:{PORT}'.format(
+                                            LOCAL_HOST=LOCAL_HOST,
+                                            PORT=ELASTICSEARCH_PORT)
+                                       )
     ELASTICSEARCH_INDEX = 'table_search_index'
     ELASTICSEARCH_AUTH_USER = 'elastic'
     ELASTICSEARCH_AUTH_PW = 'elastic'

--- a/search_service/config.py
+++ b/search_service/config.py
@@ -23,10 +23,10 @@ class LocalConfig(Config):
     LOCAL_HOST = '0.0.0.0'
     ELASTICSEARCH_PORT = '9200'
     ELASTICSEARCH_ENDPOINT = os.environ.get('ELASTICSEARCH_BASE',
-                                        'http://{LOCAL_HOST}:{PORT}'.format(
-                                            LOCAL_HOST=LOCAL_HOST,
-                                            PORT=ELASTICSEARCH_PORT)
-                                       )
+                                            'http://{LOCAL_HOST}:{PORT}'.format(
+                                                LOCAL_HOST=LOCAL_HOST,
+                                                PORT=ELASTICSEARCH_PORT)
+                                            )
     ELASTICSEARCH_INDEX = 'table_search_index'
     ELASTICSEARCH_AUTH_USER = 'elastic'
     ELASTICSEARCH_AUTH_PW = 'elastic'

--- a/search_service/config.py
+++ b/search_service/config.py
@@ -22,7 +22,7 @@ class LocalConfig(Config):
     STATS = False
     LOCAL_HOST = '0.0.0.0'
     ELASTICSEARCH_PORT = '9200'
-    ELASTICSEARCH_ENDPOINT = os.environ.get('ELASTICSEARCH_BASE',
+    ELASTICSEARCH_ENDPOINT = os.environ.get('ELASTICSEARCH_ENDPOINT',
                                             'http://{LOCAL_HOST}:{PORT}'.format(
                                                 LOCAL_HOST=LOCAL_HOST,
                                                 PORT=ELASTICSEARCH_PORT)


### PR DESCRIPTION
This PR allows the elasticsearch base to be set through an environment variable (ELASTICSEARCH_ENDPOINT), which is necessary when using it in a docker-compose setup without using docker-machine. It is similar to the environment variable support for metadata and search service available in the frontend project. 