### PR TITLE
Add endpoint for direct string query searching using lucene

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Flask==1.0.2
 Flask-RESTful==0.3.6
 itsdangerous==0.24
 Jinja2>=2.10.1
+luqum==0.8.0
 MarkupSafe==1.0
 marshmallow==3.0.0rc7
 mock==2.0.0

--- a/search_service/__init__.py
+++ b/search_service/__init__.py
@@ -8,7 +8,7 @@ from flask import Flask, Blueprint
 from flask_restful import Api
 from typing import Dict, Any    # noqa: F401
 
-from search_service.api.table import SearchTableAPI, SearchTableFieldAPI
+from search_service.api.table import SearchTableAPI, SearchTableFieldAPI, SearchStringQueryTableAPI
 from search_service.api.user import SearchUserAPI
 from search_service.api.document import DocumentTableAPI
 from search_service.api.healthcheck import healthcheck
@@ -67,6 +67,7 @@ def create_app(*, config_module_class: str) -> Flask:
     api_bp.add_url_rule('/healthcheck', 'healthcheck', healthcheck)
     api = Api(api_bp)
     # Table Search API
+    api.add_resource(SearchStringQueryTableAPI, '/search/query_string')
     api.add_resource(SearchTableAPI, '/search')
     api.add_resource(SearchTableFieldAPI,
                      '/search/field/<field_name>/field_val/<field_value>')

--- a/search_service/api/table.py
+++ b/search_service/api/table.py
@@ -69,6 +69,47 @@ class SearchTableAPI(Resource):
             return {'message': err_msg}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 
+class SearchStringQueryTableAPI(Resource):
+    """
+    Search Table API using string query syntax
+    """
+
+    def __init__(self) -> None:
+        self.proxy = get_proxy_client()
+
+        self.parser = reqparse.RequestParser(bundle_errors=True)
+
+        self.parser.add_argument('query_term', required=True, type=str)
+        self.parser.add_argument('page_index', required=False, default=0, type=int)
+        self.parser.add_argument('index', required=False, default=TABLE_INDEX, type=str)
+
+        super(SearchStringQueryTableAPI, self).__init__()
+
+    @marshal_with(search_table_results)
+    def get(self) -> Iterable[Any]:
+        """
+        Fetch search results based on string query
+        :return: list of table results. List can be empty if query
+        doesn't match any tables
+        """
+        args = self.parser.parse_args(strict=True)
+
+        try:
+
+            results = self.proxy.fetch_string_query_search_results(
+                query_string=args['query_term'],
+                page_index=args['page_index'],
+                index=args['index']
+            )
+
+            return results, HTTPStatus.OK
+
+        except RuntimeError:
+
+            err_msg = 'Exception encountered while processing search request'
+            return {'message': err_msg}, HTTPStatus.INTERNAL_SERVER_ERROR
+
+
 class SearchTableFieldAPI(Resource):
     """
     Search Table API with explict field

--- a/search_service/proxy/atlas.py
+++ b/search_service/proxy/atlas.py
@@ -213,6 +213,12 @@ class AtlasProxy(BaseProxy):
 
         return SearchResult(total_results=count_value, results=tables)
 
+    def fetch_string_query_search_results(self, *,
+                                          query_string: str,
+                                          page_index: int = 0,
+                                          index: str = '') -> SearchResult:
+        pass
+
     def fetch_user_search_results(self, *,
                                   query_term: str,
                                   page_index: int = 0,

--- a/search_service/proxy/base.py
+++ b/search_service/proxy/base.py
@@ -27,6 +27,13 @@ class BaseProxy(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def fetch_string_query_search_results(self, *,
+                                          query_string: str,
+                                          page_index: int = 0,
+                                          index: str = '') -> SearchResult:
+        pass
+
+    @abstractmethod
     def fetch_user_search_results(self, *,
                                   query_term: str,
                                   page_index: int = 0,

--- a/search_service/utils/query_transformer.py
+++ b/search_service/utils/query_transformer.py
@@ -1,0 +1,67 @@
+from luqum.utils import LuceneTreeTransformer
+from luqum.parser import parser
+from luqum.tree import UnknownOperation, SearchField, Word
+from typing import List, Optional, Union
+
+
+class QueryTransformer(LuceneTreeTransformer):
+    """
+    QueryTransformer uses the LuceneTreeTransformer to modify the query tree in place
+
+    The NAME_MAPPING values come from the table schema defined in index_map.py
+    """
+    NAME_MAPPING = {
+        'tag': 'tags',
+        'schema': 'schema_name.raw',
+        'table': 'name.raw',
+        'column': 'column_names.raw',
+        'database': 'database',
+        'description': 'description'
+    }
+
+    VALUE_MAPPING = {
+        'schema_name.raw': '^3',
+        'name.raw': '^30',
+        'column_names.raw': '^2',
+        'description': '^3'
+    }
+
+    def visit_search_field(self, node: SearchField, parents: List[UnknownOperation]) -> SearchField:
+        """
+        Built-in method called when the parser visits a search field node. This
+        method maps user input to elasticsearch mapping (as defined in index_map.py)
+        """
+        mapped: Optional[str] = self.NAME_MAPPING.get(node.name)
+        if mapped is not None:
+            node.name = mapped
+        return node
+
+    def visit_term(self, node: Word, parents: List[Union[SearchField, UnknownOperation]]) -> Word:
+        """
+        Built-in method called when the parser visits some user supplied input that
+        is not a search field.
+        """
+        if not parents:
+            return node
+
+        # The immediate parent of our node is the last element in the list
+        parent = parents[-1]
+
+        # if the parent isn't a search field, we can return early
+        if not type(parent) == SearchField:
+            return node
+
+        if parent.name == '_exists_':
+            # if the user supplies "_exists_:some_value", we want to map "some_value"
+            # to its proper name in the elasticsearch schema
+            node.value = self.NAME_MAPPING.get(node.value, node.value)
+        else:
+            # Boost some search field values higher than others
+            boost = self.VALUE_MAPPING.get(parent.name, '')
+            node.value = f'{node.value}{boost}'
+        return node
+
+    def parse(self, *, query: str) -> str:
+        parsed_query: UnknownOperation = parser.parse(query)
+        QueryTransformer().visit(parsed_query)
+        return str(parsed_query)

--- a/tests/unit/api/test_table.py
+++ b/tests/unit/api/test_table.py
@@ -1,0 +1,29 @@
+import unittest
+
+from mock import patch
+
+from search_service.api.table import SearchStringQueryTableAPI
+from search_service import create_app
+
+
+class SearchStringQueryTableAPITest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app = create_app(config_module_class='search_service.config.LocalConfig')
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tear_down(self):
+        self.app_context.pop()
+
+    @patch('search_service.api.document.reqparse.RequestParser')
+    @patch('search_service.api.table.get_proxy_client')
+    def test_get(self, get_proxy, RequestParser) -> None:
+        mock_proxy = get_proxy()
+        mock_proxy.fetch_string_query_search_results.return_value = {}
+        RequestParser().parse_args.return_value = dict(query_term='hello',
+                                                       index='fake_index',
+                                                       page_index=0)
+        SearchStringQueryTableAPI().get()
+        mock_proxy.fetch_string_query_search_results.assert_called_with(query_string='hello',
+                                                                        index='fake_index',
+                                                                        page_index=0)

--- a/tests/unit/proxy/test_elasticsearch.py
+++ b/tests/unit/proxy/test_elasticsearch.py
@@ -298,6 +298,29 @@ class TestElasticsearchProxy(unittest.TestCase):
                              "Search result doesn't match with expected result!")
 
     @patch('elasticsearch_dsl.Search.execute')
+    def test_search_with_query_string(self, mock_search: MagicMock) -> None:
+        mock_results = MagicMock()
+        mock_results.hits.total = 1
+        mock_results.__iter__.return_value = [Response(result=vars(self.mock_result1))]
+        mock_search.return_value = mock_results
+
+        expected = SearchResult(total_results=1,
+                                results=[Table(name='test_table',
+                                               key='test_key',
+                                               description='test_description',
+                                               cluster='gold',
+                                               database='test_db',
+                                               schema_name='test_schema',
+                                               column_names=['test_col1', 'test_col2'],
+                                               tags=[],
+                                               last_updated_epoch=1527283287)])
+
+        resp = self.es_proxy.fetch_string_query_search_results(query_string='test_query_term')
+        self.assertEquals(resp.total_results, expected.total_results)
+        self.assertIsInstance(resp.results[0], Table)
+        self.assertDictEqual(vars(resp.results[0]), vars(expected.results[0]))
+
+    @patch('elasticsearch_dsl.Search.execute')
     def test_search_with_one_user_result(self,
                                          mock_search: MagicMock) -> None:
 

--- a/tests/utils/test_query_transformer.py
+++ b/tests/utils/test_query_transformer.py
@@ -1,0 +1,29 @@
+import unittest
+
+from search_service.utils.query_transformer import QueryTransformer
+
+
+class QueryTransformerTest(unittest.TestCase):
+    def test_parser_simple(self) -> None:
+        result = QueryTransformer().parse(query='column:hello')
+        self.assertEqual(result, 'column_names.raw:hello^2')
+
+    def test_parser_simple_or(self) -> None:
+        result = QueryTransformer().parse(query='(test1) or (test2)')
+        self.assertEqual(result, '(test1) or (test2)')
+
+    def test_parser_multi(self) -> None:
+        result = QueryTransformer().parse(query='table:test1 table:test2')
+        self.assertEqual(result, 'name.raw:test1^30 name.raw:test2^30')
+
+    def test_parser_multi_or(self) -> None:
+        result = QueryTransformer().parse(query='table:test1 or table:test2')
+        self.assertEqual(result, 'name.raw:test1^30 or name.raw:test2^30')
+
+    def test_parser_multi_and(self) -> None:
+        result = QueryTransformer().parse(query='table:test1 and column:id')
+        self.assertEqual(result, 'name.raw:test1^30 and column_names.raw:id^2')
+
+    def test_parser_exists(self) -> None:
+        result = QueryTransformer().parse(query='_exists_:table')
+        self.assertEqual(result, '_exists_:name.raw')


### PR DESCRIPTION
### Summary of Changes

@feng-tao this is what I was working on using the Lucene parsing tree that is built into Elasticsearch.

Basically, this PR adds an endpoint for users who want to search using the elasticsearch string query language directly ([docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html))

The Elasticsearch string query language gives users more power over their search, allowing them to search on multiple fields, along with all of the other functionality described in the doc linked above.

I added a PR on amundsenfrontendlibrary to show how this endpoint could be used
https://github.com/lyft/amundsenfrontendlibrary/pull/271

### Tests

I added tests for the new endpoint, the logic in the elasticsearch proxy, and the query transformer.

### Documentation

I did not add any documentation (yet)

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
