### PR TITLE
Fixes the atlas search to not fetch related items

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aniso8601==3.0.0
-atlasclient==0.1.8
+pyatlasclient==1.0.1
 click==6.7
 elasticsearch==6.2.0
 elasticsearch-dsl==6.1.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '1.1.9'
+__version__ = '1.1.10'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/tests/unit/proxy/test_atlas.py
+++ b/tests/unit/proxy/test_atlas.py
@@ -167,8 +167,8 @@ class TestAtlasProxy(unittest.TestCase):
         :param entities:
         :return:
         """
-
-        def guid_filter(guid: List):
+        # noinspection PyPep8Naming
+        def guid_filter(guid: List, ignoreRelationships=False):
             return TestAtlasProxy.recursive_mock([{
                 'entities': list(filter(lambda x: x['guid'] in guid, entities))
             }])
@@ -203,29 +203,25 @@ class TestAtlasProxy(unittest.TestCase):
         self.assertEqual(client.page_size, 1337)
 
     def test_search_normal(self):
-        expected = SearchResult(total_results=1,
-                                results=[Table(name=self._qualified('table', 'Table1'),
-                                               key=f"TEST_ENTITY://TEST_CLUSTER."
-                                                   f"{self._qualified('db', 'TEST_DB')}/"
-                                                   f"{self._qualified('table', 'Table1')}",
-                                               description='Dummy Description',
-                                               cluster='TEST_CLUSTER',
-                                               database='TEST_ENTITY',
-                                               schema_name=self._qualified('db', 'TEST_DB'),
-                                               column_names=[
-                                               # 'column@name'
-                                               ],
+        expected = SearchResult(total_results=2,
+                                results=[Table(name=self.entity1['attributes']['name'],
+                                               key=f"{self.entity_type}://"
+                                                   f"{self.cluster}.{self.db}/"
+                                                   f"{self.entity1['attributes']['name']}",
+                                               description=self.entity1['attributes']['description'],
+                                               cluster=self.cluster,
+                                               database=self.entity_type,
+                                               schema_name=self.db,
+                                               column_names=[],
                                                tags=['PII_DATA'],
                                                last_updated_epoch=123),
                                          Table(name='Table2',
-                                               key=f"TEST_ENTITY://./Table2",
+                                               key=f"TEST_ENTITY://default.default/Table2",
                                                description='Dummy Description',
-                                               cluster='',
-                                               database='TEST_ENTITY',
-                                               schema_name='',
-                                               column_names=[
-                                                   # 'column@name'
-                                               ],
+                                               cluster='default',
+                                               database=self.entity_type,
+                                               schema_name='default',
+                                               column_names=[],
                                                tags=[],
                                                last_updated_epoch=234)])
         self.proxy.atlas.search_dsl = self.dsl_inject(
@@ -274,17 +270,15 @@ class TestAtlasProxy(unittest.TestCase):
         for field in fields:
 
             expected = SearchResult(total_results=1,
-                                    results=[Table(name=self._qualified('table', 'Table1'),
-                                                   key=f"TEST_ENTITY://TEST_CLUSTER"
-                                                       f".{self._qualified('db', 'TEST_DB')}/"
-                                                       f"{self._qualified('table', 'Table1')}",
-                                                   description='Dummy Description',
-                                                   cluster='TEST_CLUSTER',
-                                                   database='TEST_ENTITY',
-                                                   schema_name=self._qualified('db', 'TEST_DB'),
-                                                   column_names=[
-                                                   # 'column@name'
-                                                   ],
+                                    results=[Table(name=self.entity1['attributes']['name'],
+                                                   key=f"{self.entity_type}://"
+                                                       f"{self.cluster}.{self.db}/"
+                                                       f"{self.entity1['attributes']['name']}",
+                                                   description=self.entity1['attributes']['description'],
+                                                   cluster=self.cluster,
+                                                   database=self.entity_type,
+                                                   schema_name=self.db,
+                                                   column_names=[],
                                                    tags=['PII_DATA'],
                                                    last_updated_epoch=123)])
             self.proxy.atlas.search_dsl = self.dsl_inject(


### PR DESCRIPTION
### Summary of Changes

This PR restricts the atlas proxy not to fetch the related items to make the query faster, and also uses the helper function of pyatlasclient to make sure to pass the correct name of tables on the frontend. 

### Tests

Fixes the tests as per the change above. Tests are already there, no need to add new ones. 

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
