### PR TITLE
Pin docker to python 3.7

### DIFF
--- a/public.Dockerfile
+++ b/public.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.7-slim
 WORKDIR /app
 RUN pip3 install gunicorn
 


### PR DESCRIPTION
### Summary of Changes

Pin docker to python 3.7 - this way we make sure we have the `typed-ast` wheel available so we do not need gcc which is not available in the `-slim` image (part of what makes it slimmer ;).

**Note**: Since our existing docker rreleases are already baked on 3.7 they shouldn't be affected.

> Reproduced! Turns out this happened: https://docs.python.org/3/whatsnew/3.8.html
Which also means a fresh pull of `python:3` docker images are now 3.8. It looks like with python 3.7 we could rely on `.whl` files for a number of things including `typed-ast` which currently has wheels for py3.5 - 3.7, but nothing for 3.8 yet: https://pypi.org/project/typed-ast/#files
>
> I propose we pin our Dockerfiles to 3.7-slim until the dust settles on 3.8 :tornado:. I will post a PR.

Background Slack thread: https://amundsenworkspace.slack.com/archives/CHQERT0D7/p1571242121003300?thread_ts=1571215339.001400&cid=CHQERT0D7

### Tests

No automated test changes. Tested manually - To reproduce the original problem if you have an existing `python:3-slim` image hased on python <= 3.7 you need to `docker rmi` that first before you will experience the problem.

### Documentation

No changes

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
