### PR TITLE
Allow to connect to Elasticsearch through anonymous access

### DIFF
--- a/search_service/proxy/elasticsearch.py
+++ b/search_service/proxy/elasticsearch.py
@@ -49,7 +49,8 @@ class ElasticsearchProxy(BaseProxy):
         if client:
             self.elasticsearch = client
         else:
-            self.elasticsearch = Elasticsearch(host, http_auth=(user, password))
+            http_auth = (user, password) if user else None
+            self.elasticsearch = Elasticsearch(host, http_auth=http_auth)
 
         self.page_size = page_size
 

--- a/tests/unit/proxy/test_elasticsearch.py
+++ b/tests/unit/proxy/test_elasticsearch.py
@@ -126,6 +126,30 @@ class TestElasticsearchProxy(unittest.TestCase):
             self.assertEqual(client.transport.hosts[0]['host'], "0.0.0.0")
             self.assertEqual(client.transport.hosts[0]['port'], 9200)
 
+    @patch('search_service.proxy.elasticsearch.Elasticsearch', autospec=True)
+    def test_setup_client_with_username_and_password(self, elasticsearch_mock) -> None:
+        self.es_proxy = ElasticsearchProxy(
+            host='http://unit-test-host',
+            user='unit-test-user',
+            password='unit-test-pass'
+        )
+
+        elasticsearch_mock.assert_called_once()
+        elasticsearch_mock.assert_called_once_with(
+            'http://unit-test-host',
+            http_auth=('unit-test-user', 'unit-test-pass')
+        )
+
+    @patch('search_service.proxy.elasticsearch.Elasticsearch', autospec=True)
+    def test_setup_client_without_username(self, elasticsearch_mock) -> None:
+        self.es_proxy = ElasticsearchProxy(
+            host='http://unit-test-host',
+            user=''
+        )
+
+        elasticsearch_mock.assert_called_once()
+        elasticsearch_mock.assert_called_once_with('http://unit-test-host', http_auth=None)
+
     @patch('search_service.proxy._proxy_client', None)
     def test_setup_config(self) -> None:
         es: ElasticsearchProxy = get_proxy_client()


### PR DESCRIPTION
### Summary of Changes

In addition to allow for Basic Auth (via username/password), this allows to pass in an empty username, which will default to no authorization header being passed to ElasticSearch.

This is required to unblock using Amundsen with hosted use of AWS Elasticsearch. This does not allow Basic Authentication, but instead manages security through AWS Security Groups, AWS Signature v4 requests or AWS Cognito pools.

Assuming this is a good first step to simply enable this, I intend to contribute by also being able to pass in the Amazon Signature v4 signed requests. 

### Tests

I created a unit test for this change, and additionally tested connecting to an AWS Elasticsearch instance via starting the service with specified env variables: `PROXY_PORT=443 PROXY_ENDPOINT=https://<some-random-value>.eu-west-1.es.amazonaws.com/ CREDENTIALS_PROXY_USER="" python3 search_service/search_wsgi.py`

### Documentation

I did not find any existing documentation for `CREDENTIALS_PROXY_USER`, but would be happy to contribute accordingly.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
