### PR TITLE
Reenable OR operator for ES search result

### DIFF
--- a/search_service/proxy/elasticsearch.py
+++ b/search_service/proxy/elasticsearch.py
@@ -295,7 +295,6 @@ class ElasticsearchProxy(BaseProxy):
                                        "description^3",
                                        "column_names^2",
                                        "column_descriptions", "tags"],
-                            "operator": "and"
                         }
                     },
                     "field_value_factor": {
@@ -356,7 +355,6 @@ class ElasticsearchProxy(BaseProxy):
                                    "description^3",
                                    "column_names^2",
                                    "column_descriptions", "tags"],
-                        "operator": "and"
                     }
                 },
                 "field_value_factor": {
@@ -398,7 +396,6 @@ class ElasticsearchProxy(BaseProxy):
                                    "last_name^3",
                                    "email^3"],
                         "operator": "and"
-
                     }
                 }
             }

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')


### PR DESCRIPTION
We found that AND operator doesn't work for the case when user searches for X.Y(e.g schema.table) . Reenable the OR operator to mitigate the issue.