### PR TITLE
Allow all results to be shown when page index is -1

### DIFF
--- a/search_service/proxy/elasticsearch.py
+++ b/search_service/proxy/elasticsearch.py
@@ -70,9 +70,14 @@ class ElasticsearchProxy(BaseProxy):
 
         results = []
         # Use {page_index} to calculate index of results to fetch from
-        start_from = page_index * self.page_size
-        end_at = start_from + self.page_size
-        client = client[start_from:end_at]
+        if page_index != -1:
+            start_from = page_index * self.page_size
+            end_at = start_from + self.page_size
+            client = client[start_from:end_at]
+        else:
+            # if page index is -1, return everything
+            client = client[0:client.count()]
+
         response = client.execute()
 
         for hit in response:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '1.4.1'
+__version__ = '1.4.2'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')


### PR DESCRIPTION
Currently ES default will show 10 results. In order to show all results, we could provide page_index equals to -1 to do that.