### PR TITLE
Add IndexAPI

### DIFF
--- a/search_service/__init__.py
+++ b/search_service/__init__.py
@@ -11,7 +11,9 @@ from flasgger import Swagger
 
 from search_service.api.table import SearchTableAPI, SearchTableFieldAPI
 from search_service.api.user import SearchUserAPI
-from search_service.api.document import DocumentUserAPI, DocumentTableAPI, DocumentTablesAPI, DocumentUsersAPI
+from search_service.api.document import (DocumentUserAPI, DocumentTableAPI,
+                                         DocumentTablesAPI, DocumentUsersAPI)
+from search_service.api.index import IndexAPI
 from search_service.api.healthcheck import healthcheck
 
 # For customized flask use below arguments to override.
@@ -72,6 +74,9 @@ def create_app(*, config_module_class: str) -> Flask:
     api.add_resource(SearchTableAPI, '/search')
     api.add_resource(SearchTableFieldAPI,
                      '/search/field/<field_name>/field_val/<field_value>')
+
+    # Index API
+    api.add_resource(IndexAPI, '/index', '/index/<index>')
 
     # User Search API
     api.add_resource(SearchUserAPI, '/search_user')

--- a/search_service/api/index.py
+++ b/search_service/api/index.py
@@ -1,0 +1,34 @@
+import logging
+
+from flasgger import swag_from
+from http import HTTPStatus
+from typing import Tuple, Any
+from flask_restful import Resource
+
+from search_service.proxy import get_proxy_client
+from search_service.api.table import TABLE_INDEX
+
+LOGGER = logging.getLogger(__name__)
+
+
+class IndexAPI(Resource):
+
+    def __init__(self) -> None:
+        self.proxy = get_proxy_client()
+        super(IndexAPI, self).__init__()
+
+    @swag_from('swagger_doc/index/index_delete.yml')
+    def delete(self, *, index: str = TABLE_INDEX) -> Tuple[Any, int]:
+        """
+        Deletes the specified Elasticsearch index
+
+        :param index: alias or id for the index that should be deleted
+        :return:
+        """
+        try:
+            self.proxy.delete_index(index=index)
+            return {}, HTTPStatus.OK
+        except RuntimeError:
+            err_msg = 'Exception encountered while deleting index'
+            LOGGER.exception(err_msg)
+            return {'message': err_msg}, HTTPStatus.INTERNAL_SERVER_ERROR

--- a/search_service/api/swagger_doc/index/index_delete.yml
+++ b/search_service/api/swagger_doc/index/index_delete.yml
@@ -1,0 +1,25 @@
+Delete index by name
+Delete index in ElasticSearch.
+---
+tags:
+  - 'index'
+parameters:
+  - name: document_id
+    in: path
+    type: string
+    schema:
+      type: string
+    required: true
+responses:
+  200:
+    description: Empty json response
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/EmptyResponse'
+  500:
+    description: Exception encountered while deleting index
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'

--- a/search_service/proxy/atlas.py
+++ b/search_service/proxy/atlas.py
@@ -251,6 +251,9 @@ class AtlasProxy(BaseProxy):
                                   index: str = '') -> SearchResult:
         pass
 
+    def delete_index(self, *, index: str) -> str:
+        raise NotImplementedError()
+
     def update_document(self, *, data: List[Dict[str, Any]], index: str = '') -> str:
         raise NotImplementedError()
 

--- a/search_service/proxy/base.py
+++ b/search_service/proxy/base.py
@@ -34,6 +34,10 @@ class BaseProxy(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def delete_index(self, *, index: str) -> str:
+        pass
+
+    @abstractmethod
     def update_document(self, *,
                         data: List[Dict[str, Any]],
                         index: str = '') -> str:

--- a/search_service/proxy/elasticsearch.py
+++ b/search_service/proxy/elasticsearch.py
@@ -413,6 +413,19 @@ class ElasticsearchProxy(BaseProxy):
                                    model=User)
 
     @timer_with_counter
+    def delete_index(self, *, index: str) -> str:
+        # will return a TransportError if the index does not exist
+        indices: List[str] = self.elasticsearch.indices.get(index).keys()
+
+        for i in indices:
+            result: Dict[str, Any] = self.elasticsearch.indices.delete(i)
+
+            if result.get('errors'):
+                LOGGING.error(f'Error deleting Elasticsearch index {i}')
+
+        return index
+
+    @timer_with_counter
     def create_document(self, *, data: List[Table], index: str) -> str:
         """
         Creates new index in elasticsearch, then routes traffic to the new index

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ ignore = I201
 max-line-length = 120
 
 # modify --cov-fail-under parameter after adding unit tests
-[pytest]
+[tool:pytest]
 addopts = --cov=search_service --cov-fail-under=0 --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html -vvv
 
 [coverage:run]

--- a/tests/unit/api/test_index.py
+++ b/tests/unit/api/test_index.py
@@ -1,0 +1,24 @@
+import unittest
+
+from http import HTTPStatus
+from mock import patch, Mock
+
+from search_service.api.index import IndexAPI
+from search_service import create_app
+
+
+class IndexAPITest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app = create_app(config_module_class='search_service.config.LocalConfig')
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tear_down(self):
+        self.app_context.pop()
+
+    @patch('search_service.api.index.get_proxy_client')
+    def test_delete(self, get_proxy) -> None:
+        mock_proxy = get_proxy.return_value = Mock()
+        response = IndexAPI().delete(index='fake_index')
+        self.assertEqual(list(response)[1], HTTPStatus.OK)
+        mock_proxy.delete_index.assert_called_with(index='fake_index')

--- a/tests/unit/proxy/test_elasticsearch.py
+++ b/tests/unit/proxy/test_elasticsearch.py
@@ -127,7 +127,7 @@ class TestElasticsearchProxy(unittest.TestCase):
             self.assertEqual(client.transport.hosts[0]['port'], 9200)
 
     @patch('search_service.proxy.elasticsearch.Elasticsearch', autospec=True)
-    def test_setup_client_with_username_and_password(self, elasticsearch_mock) -> None:
+    def test_setup_client_with_username_and_password(self, elasticsearch_mock: MagicMock) -> None:
         self.es_proxy = ElasticsearchProxy(
             host='http://unit-test-host',
             user='unit-test-user',
@@ -141,7 +141,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         )
 
     @patch('search_service.proxy.elasticsearch.Elasticsearch', autospec=True)
-    def test_setup_client_without_username(self, elasticsearch_mock) -> None:
+    def test_setup_client_without_username(self, elasticsearch_mock: MagicMock) -> None:
         self.es_proxy = ElasticsearchProxy(
             host='http://unit-test-host',
             user=''
@@ -356,6 +356,16 @@ class TestElasticsearchProxy(unittest.TestCase):
         expected = ''
         result = self.es_proxy.create_document(data=None, index='table_search_index')
         self.assertEquals(expected, result)
+
+    def test_delete_index(self) -> None:
+        mock_elasticsearch = self.es_proxy.elasticsearch
+        index = 'index_name'
+        alias = 'user_search_index'
+
+        mock_elasticsearch.indices.get.return_value = dict([(index, {})])
+        self.es_proxy.delete_index(index=alias)
+        mock_elasticsearch.indices.get.assert_called_with(alias)
+        mock_elasticsearch.indices.delete.assert_called_with(index)
 
     @patch('uuid.uuid4')
     def test_create_document(self, mock_uuid: MagicMock) -> None:


### PR DESCRIPTION
### Summary of Changes

This PR adds an API for manipulating elasticsearch indices. Right now it only supports DELETE, which is useful for wiping out an index, as necessary (most often in local development or a staging environment)

### Tests

I added tests for the new method in elasticsearch proxy and the new API

### Documentation

I added Swagger documentation for the endpoint

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
