### PR TITLE
Cleanup mypy errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint:
 
 .PHONY: mypy
 mypy:
-	mypy --ignore-missing-imports --follow-imports=skip --strict-optional --warn-no-return search_service
+	mypy --ignore-missing-imports --follow-imports=skip --strict-optional --warn-no-return .
 
 .PHONY: test
 test: test_unit lint mypy

--- a/tests/unit/proxy/test_elasticsearch.py
+++ b/tests/unit/proxy/test_elasticsearch.py
@@ -1,8 +1,7 @@
-from typing import Any
 import unittest
-from unittest.mock import patch, MagicMock
 
-from typing import Iterable
+from unittest.mock import patch, MagicMock
+from typing import Any, Iterable
 
 from search_service import create_app
 from search_service.proxy import get_proxy_client
@@ -127,7 +126,7 @@ class TestElasticsearchProxy(unittest.TestCase):
             self.assertEqual(client.transport.hosts[0]['port'], 9200)
 
     @patch('search_service.proxy.elasticsearch.Elasticsearch', autospec=True)
-    def test_setup_client_with_username_and_password(self, elasticsearch_mock) -> None:
+    def test_setup_client_with_username_and_password(self, elasticsearch_mock: MagicMock) -> None:
         self.es_proxy = ElasticsearchProxy(
             host='http://unit-test-host',
             user='unit-test-user',
@@ -141,7 +140,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         )
 
     @patch('search_service.proxy.elasticsearch.Elasticsearch', autospec=True)
-    def test_setup_client_without_username(self, elasticsearch_mock) -> None:
+    def test_setup_client_without_username(self, elasticsearch_mock: MagicMock) -> None:
         self.es_proxy = ElasticsearchProxy(
             host='http://unit-test-host',
             user=''
@@ -152,7 +151,7 @@ class TestElasticsearchProxy(unittest.TestCase):
 
     @patch('search_service.proxy._proxy_client', None)
     def test_setup_config(self) -> None:
-        es: ElasticsearchProxy = get_proxy_client()
+        es: Any = get_proxy_client()
         a = es.elasticsearch
         for client in [a, a.cat, a.cluster, a.indices, a.ingest, a.nodes, a.snapshot, a.tasks]:
             self.assertEqual(client.transport.hosts[0]['host'], "0.0.0.0")

--- a/tests/unit/test_swagger.py
+++ b/tests/unit/test_swagger.py
@@ -1,5 +1,7 @@
 import unittest
 
+from typing import Any, Dict
+
 from search_service import create_app
 
 
@@ -58,7 +60,7 @@ class TestSwagger(unittest.TestCase):
                 self.fail(f'The following endpoint is not in swagger: {endpoint}')
 
     @staticmethod
-    def find(key, json_response):
+    def find(key: str, json_response: Dict[str, Any]) -> Any:
         for json_key, json_value in json_response.items():
             if json_key == key:
                 yield json_value


### PR DESCRIPTION
### Summary of Changes

The `make test` `mypy` command was only looking in the `search_service` folder, which completely misses test files. I updated the command and cleaned up the typing in test files.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes. 
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes `make test`
