### PR TITLE
Fix bug in filter endpoint

### DIFF
--- a/search_service/api/table.py
+++ b/search_service/api/table.py
@@ -160,7 +160,7 @@ class SearchTableFilterAPI(Resource):
             msg = 'The search request payload is not available in the request'
             return {'message': msg}, HTTPStatus.BAD_REQUEST
 
-        query_term = args.get('query_term')  # typeL str
+        query_term = args.get('query_term')  # type: str
         if ':' in query_term:
             msg = 'The query term contains an invalid character'
             return {'message': msg}, HTTPStatus.BAD_REQUEST

--- a/search_service/api/table.py
+++ b/search_service/api/table.py
@@ -160,10 +160,15 @@ class SearchTableFilterAPI(Resource):
             msg = 'The search request payload is not available in the request'
             return {'message': msg}, HTTPStatus.BAD_REQUEST
 
+        query_term = args.get('query_term')  # typeL str
+        if ':' in query_term:
+            msg = 'The query term contains an invalid character'
+            return {'message': msg}, HTTPStatus.BAD_REQUEST
+
         try:
             results = self.proxy.fetch_table_search_results_with_filter(
                 search_request=search_request,
-                query_term=args.get('query_term'),
+                query_term=query_term,
                 page_index=page_index,
                 index=args['index']
             )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '2.1.3'
+__version__ = '2.1.4'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/tests/unit/api/table/test_search_table_filter.py
+++ b/tests/unit/api/table/test_search_table_filter.py
@@ -48,3 +48,14 @@ class SearchTableFilterTest(unittest.TestCase):
 
         response = self.app.test_client().post(self.url)
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+    @patch('search_service.api.document.reqparse.RequestParser')
+    @patch('search_service.api.table.get_proxy_client')
+    def test_post_return_400_if_bad_query_term(self, get_proxy, RequestParser) -> None:
+        RequestParser().parse_args.return_value = dict(index=self.mock_index,
+                                                       page_index=self.mock_page_index,
+                                                       query_term='column:bad_syntax',
+                                                       search_request=self.mock_search_request)
+
+        response = self.app.test_client().post(self.url)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)


### PR DESCRIPTION
### Summary of Changes
When using the filter endpoint, the `query_term` cannot contain a `:`. The service throws an error, likely because of [this logic](https://github.com/lyft/amundsensearchlibrary/blob/master/search_service/proxy/elasticsearch.py#L428-L435) that will not work as expected if the `query_term` itself has a `:`.

### Tests

Added a test to cover the case.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
