### PR TITLE
update document api for marshmallow v2.15.3

### DIFF
--- a/search_service/api/document.py
+++ b/search_service/api/document.py
@@ -59,7 +59,7 @@ class BaseDocumentsAPI(Resource):
         args = self.parser.parse_args()
 
         try:
-            data = self.schema(many=True, unknown='EXCLUDE').loads(args.get('data'))
+            data = self.schema(many=True, strict=False).loads(args.get('data')).data
             results = self.proxy.create_document(data=data, index=args.get('index'))
             return results, HTTPStatus.OK
         except RuntimeError as e:
@@ -79,7 +79,7 @@ class BaseDocumentsAPI(Resource):
         args = self.parser.parse_args()
 
         try:
-            data = self.schema(many=True, unknown='EXCLUDE').loads(args.get('data'))
+            data = self.schema(many=True, strict=False).loads(args.get('data')).data
             results = self.proxy.update_document(data=data, index=args.get('index'))
             return results, HTTPStatus.OK
         except RuntimeError as e:

--- a/tests/unit/api/document/test_document_tables_api.py
+++ b/tests/unit/api/document/test_document_tables_api.py
@@ -16,29 +16,25 @@ class TestDocumentTablesAPI(unittest.TestCase):
     def tear_down(self) -> None:
         self.app_context.pop()
 
-    @patch('search_service.api.document.TableSchema')
     @patch('search_service.api.document.reqparse.RequestParser')
     @patch('search_service.api.document.get_proxy_client')
-    def test_post(self, get_proxy: MagicMock, RequestParser: MagicMock, TableSchema: MagicMock) -> None:
+    def test_post(self, get_proxy: MagicMock, RequestParser: MagicMock) -> None:
         mock_proxy = get_proxy.return_value = Mock()
-        RequestParser().parse_args.return_value = dict(data='{}', index='fake_index')
-        expected_value = TableSchema().loads.return_value = Mock()
+        RequestParser().parse_args.return_value = dict(data='[]', index='fake_index')
 
         response = DocumentTablesAPI().post()
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        mock_proxy.create_document.assert_called_with(data=expected_value, index='fake_index')
+        mock_proxy.create_document.assert_called_with(data=[], index='fake_index')
 
-    @patch('search_service.api.document.TableSchema')
     @patch('search_service.api.document.reqparse.RequestParser')
     @patch('search_service.api.document.get_proxy_client')
-    def test_put(self, get_proxy: MagicMock, RequestParser: MagicMock, TableSchema: MagicMock) -> None:
+    def test_put(self, get_proxy: MagicMock, RequestParser: MagicMock) -> None:
         mock_proxy = get_proxy.return_value = Mock()
         RequestParser().parse_args.return_value = dict(data='{}', index='fake_index')
-        expected_value = TableSchema().loads.return_value = Mock()
 
         response = DocumentTablesAPI().put()
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        mock_proxy.update_document.assert_called_with(data=expected_value, index='fake_index')
+        mock_proxy.update_document.assert_called_with(data=[], index='fake_index')
 
     def test_should_not_reach_create_with_id(self) -> None:
         response = self.app.test_client().post('/document_table/1')

--- a/tests/unit/api/document/test_document_users_api.py
+++ b/tests/unit/api/document/test_document_users_api.py
@@ -16,29 +16,25 @@ class TestDocumentUsersAPI(unittest.TestCase):
     def tear_down(self) -> None:
         self.app_context.pop()
 
-    @patch('search_service.api.document.UserSchema')
     @patch('search_service.api.document.reqparse.RequestParser')
     @patch('search_service.api.document.get_proxy_client')
-    def test_post(self, get_proxy: MagicMock, RequestParser: MagicMock, UserSchema: MagicMock) -> None:
+    def test_post(self, get_proxy: MagicMock, RequestParser: MagicMock) -> None:
         mock_proxy = get_proxy.return_value = Mock()
         RequestParser().parse_args.return_value = dict(data='{}', index='fake_index')
-        expected_value = UserSchema().loads.return_value = Mock()
 
         response = DocumentUsersAPI().post()
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        mock_proxy.create_document.assert_called_with(data=expected_value, index='fake_index')
+        mock_proxy.create_document.assert_called_with(data=[], index='fake_index')
 
-    @patch('search_service.api.document.UserSchema')
     @patch('search_service.api.document.reqparse.RequestParser')
     @patch('search_service.api.document.get_proxy_client')
-    def test_put(self, get_proxy: MagicMock, RequestParser: MagicMock, UserSchema: MagicMock) -> None:
+    def test_put(self, get_proxy: MagicMock, RequestParser: MagicMock) -> None:
         mock_proxy = get_proxy.return_value = Mock()
         RequestParser().parse_args.return_value = dict(data='{}', index='fake_index')
-        expected_value = UserSchema().loads.return_value = Mock()
 
         response = DocumentUsersAPI().put()
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        mock_proxy.update_document.assert_called_with(data=expected_value, index='fake_index')
+        mock_proxy.update_document.assert_called_with(data=[], index='fake_index')
 
     def test_should_not_reach_create_with_id(self) -> None:
         response = self.app.test_client().post('/document_user/1')


### PR DESCRIPTION
### Summary of Changes
* This [change](https://github.com/lyft/amundsensearchlibrary/pull/81/files#diff-b4ef698db8ca845e5845c4618278f29a) to the version of `marshmallow` (the version used in the other Amundsen services) broke the Document API because the `unknown` parameter it was using is not available until `marshmallow` 3.0.0+
* PR updates the API to work with `marshmallow` v2.15.3

### Tests
* Modified tests for Document API so they do not mock the schema and would have caught this error

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
