### PR TITLE
Bug fix search table filter invalid char

### DIFF
--- a/search_service/api/table.py
+++ b/search_service/api/table.py
@@ -1,6 +1,5 @@
 from http import HTTPStatus
 from typing import Any, Dict, Iterable  # noqa: F401
-import itertools
 
 from flask_restful import Resource, fields, marshal_with, reqparse
 from flasgger import swag_from
@@ -161,16 +160,6 @@ class SearchTableFilterAPI(Resource):
         if search_request is None:
             msg = 'The search request payload is not available in the request'
             return {'message': msg}, HTTPStatus.BAD_REQUEST
-
-        if 'filters' in search_request:
-            filter_values_list = search_request['filters'].values()
-            filter_values_list = list(
-                map(lambda x: x if type(x) == list else [x], filter_values_list))  # Ensure all values are arrays
-            filter_values_list = list(itertools.chain.from_iterable(filter_values_list))  # Flatten the array of arrays
-            if any(("/" in str(item) or ":" in str(item)) for item in
-                   (filter_values_list)):  # Check if / or : exist in any of the values
-                msg = 'The search filters contain an invalid character'
-                return {'message': msg}, HTTPStatus.BAD_REQUEST
 
         query_term = args.get('query_term')  # type: str
         if ':' in query_term:

--- a/search_service/api/table.py
+++ b/search_service/api/table.py
@@ -1,9 +1,9 @@
 from http import HTTPStatus
 from typing import Any, Dict, Iterable  # noqa: F401
+import itertools
 
 from flask_restful import Resource, fields, marshal_with, reqparse
 from flasgger import swag_from
-
 
 from search_service.proxy import get_proxy_client
 
@@ -132,6 +132,7 @@ class SearchTableFilterAPI(Resource):
     This API should be generic enough to support every search filter use case.
     TODO: Deprecate the SearchTableFieldAPI for this more flexible API
     """
+
     def __init__(self) -> None:
         self.proxy = get_proxy_client()
 
@@ -160,6 +161,14 @@ class SearchTableFilterAPI(Resource):
         if search_request is None:
             msg = 'The search request payload is not available in the request'
             return {'message': msg}, HTTPStatus.BAD_REQUEST
+
+        if 'filters' in search_request:
+            filter_values_list = search_request['filters'].values()
+            filter_values_list = list(map(lambda x: x if type(x) == list else [x], filter_values_list))  # Ensure all values are arrays
+            filter_values_list = list(itertools.chain.from_iterable(filter_values_list))  # Flatten the array of arrays
+            if any(("/" in str(item) or ":" in str(item)) for item in (filter_values_list)):  # Check if / or : exist in any of the values
+                msg = 'The search filters contain an invalid character'
+                return {'message': msg}, HTTPStatus.BAD_REQUEST
 
         query_term = args.get('query_term')  # type: str
         if ':' in query_term:

--- a/search_service/api/table.py
+++ b/search_service/api/table.py
@@ -164,9 +164,11 @@ class SearchTableFilterAPI(Resource):
 
         if 'filters' in search_request:
             filter_values_list = search_request['filters'].values()
-            filter_values_list = list(map(lambda x: x if type(x) == list else [x], filter_values_list))  # Ensure all values are arrays
+            filter_values_list = list(
+                map(lambda x: x if type(x) == list else [x], filter_values_list))  # Ensure all values are arrays
             filter_values_list = list(itertools.chain.from_iterable(filter_values_list))  # Flatten the array of arrays
-            if any(("/" in str(item) or ":" in str(item)) for item in (filter_values_list)):  # Check if / or : exist in any of the values
+            if any(("/" in str(item) or ":" in str(item)) for item in
+                   (filter_values_list)):  # Check if / or : exist in any of the values
                 msg = 'The search filters contain an invalid character'
                 return {'message': msg}, HTTPStatus.BAD_REQUEST
 

--- a/search_service/proxy/elasticsearch.py
+++ b/search_service/proxy/elasticsearch.py
@@ -418,7 +418,7 @@ class ElasticsearchProxy(BaseProxy):
             if mapped_category is None:
                 LOGGING.warn(f'Unsupported filter category: {category} passed in list of filters')
             elif item_list is '' or item_list == ['']:
-                LOGGING.warn(f'The filter value cannot be empty.In this case the filter {category} gets ignored')
+                LOGGING.warn(f'The filter value cannot be empty.In this case the filter {category} is ignored')
             else:
                 query_list.append(mapped_category + ':' + '(' + ' OR '.join(item_list) + ')')
 

--- a/search_service/proxy/elasticsearch.py
+++ b/search_service/proxy/elasticsearch.py
@@ -431,12 +431,13 @@ class ElasticsearchProxy(BaseProxy):
     def validate_filter_values(search_request: dict) -> Any:
         if 'filters' in search_request:
             filter_values_list = search_request['filters'].values()
-            filter_values_list = list( # Ensure all values are arrays
+            # Ensure all values are arrays
+            filter_values_list = list(
                 map(lambda x: x if type(x) == list else [x], filter_values_list))
             # Flatten the array of arrays
             filter_values_list = list(itertools.chain.from_iterable(filter_values_list))
+            # Check if / or : exist in any of the values
             if any(("/" in str(item) or ":" in str(item)) for item in (filter_values_list)):
-                # Check if / or : exist in any of the values
                 return False
             return True
 

--- a/search_service/proxy/elasticsearch.py
+++ b/search_service/proxy/elasticsearch.py
@@ -431,9 +431,10 @@ class ElasticsearchProxy(BaseProxy):
     def validate_filter_values(search_request: dict) -> Any:
         if 'filters' in search_request:
             filter_values_list = search_request['filters'].values()
-            filter_values_list = list(
-                map(lambda x: x if type(x) == list else [x], filter_values_list))  # Ensure all values are arrays
-            filter_values_list = list(itertools.chain.from_iterable(filter_values_list))  # Flatten the array of arrays
+            filter_values_list = list( # Ensure all values are arrays
+                map(lambda x: x if type(x) == list else [x], filter_values_list))
+            # Flatten the array of arrays
+            filter_values_list = list(itertools.chain.from_iterable(filter_values_list))
             if any(("/" in str(item) or ":" in str(item)) for item in (filter_values_list)):
                 # Check if / or : exist in any of the values
                 return False
@@ -488,7 +489,7 @@ class ElasticsearchProxy(BaseProxy):
             valid_filters = self.validate_filter_values(search_request)
             if valid_filters is False:
                 raise Exception(
-                    'The search filters contain an invalid character : or / and thus cannot be handled by ElasticSearch')
+                    'The search filters contain invalid characters and thus cannot be handled by ES')
             query_dsl = self.parse_filters(filter_list)
 
         if query_term:

--- a/tests/unit/proxy/test_elasticsearch.py
+++ b/tests/unit/proxy/test_elasticsearch.py
@@ -480,7 +480,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         }
 
         expected_result = self.es_proxy.parse_filters(test_filters) + " AND " + \
-                          self.es_proxy.parse_query_term(term)
+            self.es_proxy.parse_query_term(term)
         ret_result = self.es_proxy.convert_query_json_to_query_dsl(search_request=search_request,
                                                                    query_term=term)
         self.assertEquals(ret_result, expected_result)

--- a/tests/unit/proxy/test_elasticsearch.py
+++ b/tests/unit/proxy/test_elasticsearch.py
@@ -433,6 +433,30 @@ class TestElasticsearchProxy(unittest.TestCase):
         }
         self.assertEquals(self.es_proxy.parse_filters(filter_list), '')
 
+    def test_validate_wrong_filters_values(self) -> None:
+        search_request = {
+            "type": "AND",
+            "filters": {
+                "schema": ["test_schema:test_schema"],
+                "table": ["test/table"]
+            },
+            "query_term": "",
+            "page_index": 0
+        }
+        self.assertEquals(self.es_proxy.validate_filter_values(search_request), False)
+
+    def test_validate_accepted_filters_values(self) -> None:
+        search_request = {
+            "type": "AND",
+            "filters": {
+                "schema": ["test_schema"],
+                "table": ["test_table"]
+            },
+            "query_term": "a",
+            "page_index": 0
+        }
+        self.assertEquals(self.es_proxy.validate_filter_values(search_request), True)
+
     def test_parse_query_term(self) -> None:
         term = 'test'
         expected_result = "(name:(*test*) OR name:(test) OR schema:(*test*) OR " \
@@ -456,7 +480,7 @@ class TestElasticsearchProxy(unittest.TestCase):
         }
 
         expected_result = self.es_proxy.parse_filters(test_filters) + " AND " + \
-            self.es_proxy.parse_query_term(term)
+                          self.es_proxy.parse_query_term(term)
         ret_result = self.es_proxy.convert_query_json_to_query_dsl(search_request=search_request,
                                                                    query_term=term)
         self.assertEquals(ret_result, expected_result)


### PR DESCRIPTION
### Summary of Changes

_Include a summary of changes then remove this line_
When a user was passing through postman or the UI in the search_table endpoint a request with query_term= '' and filters: {schema: ["*a:a*"]}  like in the values for each of the filters if there was ':' or  '/' then it would return 500s.

### Tests

I tried to add tests in the test_search_table_filter, but it was a bit of a pain in the ass. Spent quite some time but adding a test seems to me confusing or even itself buggy over there.
My intention was to add something like:
 @patch('search_service.api.document.reqparse.RequestParser')
    @patch('search_service.api.table.get_proxy_client')
    def test_post2(self, get_proxy: MagicMock, RequestParser: MagicMock) -> None:
        RequestParser().parse_args.return_value = dict(index=self.mock_index,
                                                       page_index=self.mock_page_index,
                                                       query_term=self.mock_empty_term,
                                                       search_request=self.mock_bad_search_request)

        response = self.app.test_client().post(self.url)
        self.assertEqual(response.status_code, 400)

where in the setUp we have defined:
        self.mock_empty_term = ''
  self.mock_bad_search_request = {
            'type': 'AND',
            'filters': {
                'database': ['d:b']
            }
        }

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
