### PR TITLE
Revert to proper Table key rendering (AtlasProxy)

### DIFF
--- a/search_service/proxy/atlas.py
+++ b/search_service/proxy/atlas.py
@@ -4,7 +4,7 @@ from atlasclient.client import Atlas
 from atlasclient.exceptions import BadRequest
 from atlasclient.models import Entity, EntityCollection
 # default search page size
-from atlasclient.utils import parse_table_qualified_name, make_table_qualified_name
+from atlasclient.utils import parse_table_qualified_name
 from typing import Any, List, Dict, Tuple, Optional
 from re import sub
 
@@ -88,7 +88,7 @@ class AtlasProxy(BaseProxy):
             badges: List[Tag] = tags
 
             table = Table(name=entity_name,
-                          key=make_table_qualified_name(entity_name, db_cluster, db_name),
+                          key=f"{entity.typeName}://{db_cluster}.{db_name}/{entity_name}",
                           description=entity_attrs.get('description'),
                           cluster=db_cluster,
                           database=entity.typeName,

--- a/tests/unit/proxy/test_atlas.py
+++ b/tests/unit/proxy/test_atlas.py
@@ -2,7 +2,6 @@ import unittest
 
 from mock import MagicMock, patch
 from typing import Any, Callable, Dict, List, Tuple
-from atlasclient.utils import make_table_qualified_name
 
 from search_service import create_app, config
 from search_service.models.search_result import SearchResult
@@ -221,7 +220,9 @@ class TestAtlasProxy(unittest.TestCase):
     def test_search_normal(self) -> None:
         expected = SearchResult(total_results=2,
                                 results=[Table(name=self.entity1_name,
-                                               key=make_table_qualified_name(self.entity1_name, self.cluster, self.db),
+                                               key=f"{self.entity_type}://"
+                                                   f"{self.cluster}.{self.db}/"
+                                                   f"{self.entity1_name}",
                                                description=self.entity1_description,
                                                cluster=self.cluster,
                                                database=self.entity_type,


### PR DESCRIPTION
### Summary of Changes

This PR reverts the change with rendering `key` field in Table object.

Having key in previous format is required for amundsenmetadatalibrary features like bookmarks to work properly.

### Tests

Adjusted tests and run to completion.

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
